### PR TITLE
Add macros to generate HPM headers

### DIFF
--- a/link.x
+++ b/link.x
@@ -4,6 +4,8 @@ PROVIDE(_stack_size = 0x4000);
 __stack_size = DEFINED(_stack_size) ? _stack_size : 0x4000;
 ASSERT(__stack_size >= 0x400, "Stack size too small");
 
+PROVIDE(_flash_config = 0x80000400);
+PROVIDE(_boot_header = 0x80001000);
 PROVIDE(_stext = ORIGIN(REGION_TEXT));
 PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
 PROVIDE(_max_hart_id = 0);
@@ -39,6 +41,18 @@ PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 SECTIONS
 {
+    .flash_config _flash_config:
+    {
+        KEEP(*(.flash_config));
+    } > REGION_HEADER
+    
+    .boot_header _boot_header :
+    {
+        __boot_header_start__ = .;
+        KEEP(*(.boot_header));
+        KEEP(*(.fw_info_table));
+    } > REGION_HEADER
+
     .start : {
         . = ALIGN(8);
         KEEP(*(.start))
@@ -191,6 +205,14 @@ SECTIONS
 
     .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
     .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+
+    .flash_end :
+    {
+        __flash_end__ = .;
+    } > XPI0_APP
+
+    __fw_size__ = __flash_end__ - _start;
+    __fw_offset__ = _start - __boot_header_start__;
 }
 
 /* Do not exceed this mark in the error messages above                                    | */

--- a/link.x
+++ b/link.x
@@ -4,8 +4,6 @@ PROVIDE(_stack_size = 0x4000);
 __stack_size = DEFINED(_stack_size) ? _stack_size : 0x4000;
 ASSERT(__stack_size >= 0x400, "Stack size too small");
 
-PROVIDE(_flash_config = 0x80000400);
-PROVIDE(_boot_header = 0x80001000);
 PROVIDE(_stext = ORIGIN(REGION_TEXT));
 PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
 PROVIDE(_max_hart_id = 0);
@@ -41,12 +39,12 @@ PROVIDE(ExceptionHandler = DefaultExceptionHandler);
 
 SECTIONS
 {
-    .flash_config _flash_config:
+    .flash_config 0x80000400 :
     {
         KEEP(*(.flash_config));
     } > REGION_HEADER
-    
-    .boot_header _boot_header :
+
+    .boot_header 0x80001000 :
     {
         __boot_header_start__ = .;
         KEEP(*(.boot_header));

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,88 @@
+#[repr(C)]
+pub struct FwContainerHeader {
+    pub tag: u8,
+    pub version: u8,
+    pub length: u16,
+    pub flags: u32,
+    pub sw_version: u16,
+    pub fuse_version: u8,
+    pub number_of_fw: u8,
+    pub device_config_block_offset: u16,
+    pub signature_block_offset: u16,
+}
+
+type LinkerScriptSymbol = unsafe extern "C" fn();
+
+#[repr(C)]
+pub struct FwInfoTable {
+    pub offset: LinkerScriptSymbol,
+    pub size: LinkerScriptSymbol,
+    pub flags: u32,
+    pub _reserved1: u32,
+    pub load_addr: LinkerScriptSymbol,
+    pub _reserved2: u32,
+    pub entry_point: LinkerScriptSymbol,
+    pub _reserved3: u32,
+    pub hash: [u8; 64],
+    pub _reserved4: [u8; 32],
+}
+
+pub mod linker_script_symbols {
+    extern "C" {
+        pub fn _start();
+        pub fn __fw_size__();
+        pub fn __fw_offset__();
+    }
+}
+
+#[macro_export]
+macro_rules! hpm_firmware_headers {
+    ($sw_version:expr) => {
+        mod __hpm_firmware_header {
+            use $crate::header::{linker_script_symbols::*, FwContainerHeader, FwInfoTable};
+            #[link_section = ".boot_header"]
+            #[allow(dead_code)]
+            #[no_mangle]
+            pub static FW_CONTAINER_HEADER: FwContainerHeader = FwContainerHeader {
+                tag: 0xBF,
+                version: 0x10,
+                length: (core::mem::size_of::<FwContainerHeader>()
+                    + core::mem::size_of::<FwInfoTable>()) as u16,
+                flags: 0x00,
+                sw_version: $sw_version,
+                fuse_version: 0x00,
+                number_of_fw: 0x01,
+                device_config_block_offset: 0x00,
+                signature_block_offset: 0x00,
+            };
+
+            #[link_section = ".fw_info_table"]
+            #[allow(dead_code)]
+            #[no_mangle]
+            pub static FW_INFO_TABLE: FwInfoTable = FwInfoTable {
+                offset: __fw_offset__,
+                size: __fw_size__,
+                flags: 0x00,
+                _reserved1: 0x00,
+                load_addr: _start,
+                _reserved2: 0x00,
+                entry_point: _start,
+                _reserved3: 0x00,
+                hash: [0; 64],
+                _reserved4: [0; 32],
+            };
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! hpm_flash_config_header {
+    () => {
+        mod __hpm_flash_header {
+            #[link_section = ".flash_config"]
+            #[allow(dead_code)]
+            #[no_mangle]
+            pub static FLASH_CONFIG: [u32; 4] = [0xfcf90002, 0x00000006, 0x1000, 0x0];
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub use hpm_riscv_rt_macros::{entry, fast, interrupt, pre_init};
 
 pub mod trap;
 
+pub mod header;
+
 /// Parse cfg attributes inside a global_asm call.
 macro_rules! cfg_global_asm {
     {@inner, [$($x:tt)*], } => {


### PR DESCRIPTION
Based on https://github.com/hpmicro-rs/hpm-riscv-rt/pull/1 (please merge that first before considering this one)

This adds macros to generate firmware headers (located in 0x80001000) and flash headers (located in 0x80000400), similar to [hpm_bootheader.c](https://github.com/hpmicro/hpm_sdk/blob/main/soc/HPM5300/HPM5361/boot/hpm_bootheader.c) and [board.c](https://github.com/hpmicro/hpm_sdk/blob/276af9395fde9ca963ac5bf7ad1e516163168bfa/boards/hpm5300evk/board.c#L74C1-L74C117) from hpm_sdk.

Users can use it as needed:

```
use hpm_riscv_rt::{hpm_firmware_headers, hpm_flash_config_header};

hpm_firmware_headers!(0x00); // 0x00 = SW version
hpm_flash_config_header!();
```

I'm not sure, though, whether this should be put into this repo, or hpm-hal repo.